### PR TITLE
Edits from the Igalia Explainer

### DIFF
--- a/QUESTIONS.md
+++ b/QUESTIONS.md
@@ -1,30 +1,46 @@
 # Open Design Questions
 
-## **Privacy-preserving rendering**
+## Privacy-preserving rendering
 
-placeElement can taint the canvas2D as needed, so even cross-origin content could eventually be placed without privacy issues. For drawElement, there’s no tainting mechanism for WebGL/WebGPU but even if it existed, the existence of shaders makes it that all rendered content should be assumed to be readable by the page. This is why WebGL/WebGPU today disallows rendering cross-origin images.
+`placeElement` can taint the canvas2D as needed, so even cross-origin content could eventually be placed without privacy issues. For `drawElement`, there’s no tainting mechanism for WebGL/WebGPU but even if it existed, the existence of shaders makes it that all rendered content should be assumed to be readable by the page. This is why WebGL/WebGPU today disallows rendering cross-origin images.
 
-To support drawElement at all, we need to make sure that the rendering of the elements is done in a privacy-preserving way. Visited links may be changing soon to be domain-based. But other issues (like dictionary spelling) may need to be disabled.
+To support `drawElement` at all, we need to make sure that the rendering of the elements is done in a privacy-preserving way. Visited links may be changing soon to be domain-based. But other issues (like dictionary spelling) may need to be disabled. There is precedent for this in SVG-as-image `foreignObject` handling.
 
-## **Complexity of rendering certain elements**
+## Complexity of rendering certain elements
 
-It’s possible that some elements may not be renderable to a texture (2D or 3D). For those cases, we are ready to have an initial disallowed list of elements to simplify implementation by UAs. For those cases, placeElement() could return null to indicate this placeElement is not supported.
+It’s possible that some elements may not be renderable to a texture (2D or 3D). For those cases, we are ready to have an initial disallowed list of elements to simplify implementation by UAs. For those cases, `placeElement()` could return null to indicate this `placeElement` is not supported.
 
 ## **Re-compositing for placeElement**
 
-placeElement requires the browser to recompose the canvas buffer each time the element changes. This should be equivalent to rendering all commands executed on the canvas with the latest contents for each placed element. If implemented as such, this would be inefficient since the buffer of commands can grow unbounded.
+`placeElement` requires the browser to recompose the canvas buffer each time the element changes. This should be equivalent to rendering all commands executed on the canvas with the latest contents for each placed element. If implemented as such, this would be inefficient since the buffer of commands can grow unbounded.
 
-The browser could optimize by squashing sets of commands into buffers at placeElement boundaries whenever possible (each saveLayer would also need to split up?).
+The browser could optimize by squashing sets of commands into buffers at `placeElement` boundaries whenever possible (each `saveLayer` would also need to split up?).
 
-## **Hit Testing Data structures**
+## Hit Testing Data structures
 
 The canvas subtree is laid out based on the DOM/style applied to the elements. However, their contents are not painted based on the position or ordering of their boxes. It is instead defined by the canvas commands which render the element’s image into the canvas buffer.
 
-This affects both hit-testing and behaviour of platform APIs (like IntersectionObserver) which allows authors to observe the position of these elements. This is the data provided by CanvasDrawElements::updateElement API for drawElement mode and done automatically by the browser for placeElement mode.
+This affects both hit-testing and behaviour of platform APIs (like `IntersectionObserver`) which allows authors to observe the position of these elements. This is the data provided by `CanvasDrawElements::updateElement` API for drawElement mode and done automatically by the browser for `placeElement` mode.
+
+## Accessibility
+
+Elements in fallback content which are passed to `placeElement()`
+are still exposed to assistive technology APIs,
+just like all other canvas fallback content.
+
+If authors wish to use canvas fallback content as a "staging area"
+for content which may later be shown to sighted users using `placeElement()`,
+they should take care to hide that content from assistive technology.
+This can be done with any of the usual techniques
+for hiding content from assistive technology,
+such as using the `hidden`, `inert` or `aria-hidden` attributes,
+or applying a `display: none` or `display: hidden` style.
+
+Browsers cannot automate this because they do not know which fallback content is for non-`placeElement` portions of the canvas, and hence should remain accessible. Some mechanism could be defined for distinguishing the two different use cases for fallback content.
 
 ## Other issues
 
-1. Should placed elements be direct children of the canvas or any descendant is ok? Might be harder to fake the element’s rendered position in the canvas if there are boxes between the canvas and the element in the tree.
+1. Should placed elements be direct children of the canvas or any descendant is ok? Might be harder to fake the element’s rendered position in the canvas if there are boxes between the canvas and the element in the tree. Any descendant would also reuire complex testing to see if the content was already placed due to a ancestor.
 2. How are non-placed canvas children represented in the layout tree. We likely need to layout the entire subtree (especially if a placed element can be a descendant) and make everything not placed visibility: hidden so they are not painted and inert.
 3. Should we force containment (layout or paint) on canvas to ensure the children don’t affect the layout of the rest of the Document?
 4. Is it worth providing the invalidation rect (based on element bounds) or will authors always do full redraw?
@@ -32,11 +48,12 @@ This affects both hit-testing and behaviour of platform APIs (like IntersectionO
 6. When painting the elements, which box should be painted? Should it include shadow? If so, how does the developer know what is the full rendered size?
 7. If developers want to align placeElements (either by baseline or box), how are they supposed to do it?
 8. What happens to placed inline elements?
-9. Clarify the timing for when the image is generated when using drawImage. Ideally it should be at the end of all script callbacks during [update the rendering](https://html.spec.whatwg.org/\#update-the-rendering) but unclear whether that’s possible for 3D.
-10. The author might draw a subset of the element. Should we add a “src rect” to updateElement.
-11. Should we allow a place element to be a descendant of another place element? It will cause double draw of the descendant and also make it harder to reason about the element’s onscreen position.
-12. Placed elements must be stacking contexts. Do we need any other restriction?
-13. Should we force blockifying canvas children?
-14. place element vs draw element for 2d canvas
+9. Clarify the timing for when the image is generated when using `drawImage`. Ideally it should be at the end of all script callbacks during [update the rendering](https://html.spec.whatwg.org/\#update-the-rendering) but unclear whether that’s possible for 3D.
+10. The author might draw a subset of the element. Should we add a “src rect” to updateElement. This would then define the containing block dimensions for resolving percentages, container queries, etc.
+11. Placed elements must be stacking contexts. Do we need any other restriction?
+12. Should we force blockifying canvas children?
+13. What about viewport-relative CSS units? Should the viewport be the canvas?
+14. What is the element's intrinsic size for drawImage etc?
+15. Code infrastructure similar to `drawElement` may make it possible to implement the [`element()`](https://developer.mozilla.org/en-US/docs/Web/CSS/element) image source in html (used in background rendering).
 
 


### PR DESCRIPTION
I made a bunch of edits before putting this up (three months ago?) on the Igalia Explainers site. https://github.com/Igalia/explainers/blob/main/canvas-formatted-text/html-in-canvas.md?plain=1

That site also has the other components including additional text metrics. Is that up someplace else too?